### PR TITLE
Add optional output array parameter to toBitDepth()

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ console.log(samples);
  *      One of "8", "16", "24", "32", "32f", "64"
  * @param {string} targetBitDepth The new bit depth of the data.
  *      One of "8", "16", "24", "32", "32f", "64"
+ * @param {Array<number>=} outputArray An optional array to write converted samples to.
+ *      Useful for writing to typed arrays.
  */
-function toBitDepth(samples, originalBitDepth, targetBitDepth) {}
+function toBitDepth(samples, originalBitDepth, targetBitDepth, outputArray) {}
 ```
 
 ## LICENSE

--- a/index.js
+++ b/index.js
@@ -92,9 +92,12 @@ const CODECS = {
  *      One of "8", "16", "24", "32", "32f", "64"
  * @param {string} targetBitDepth The new bit depth of the data.
  *      One of "8", "16", "24", "32", "32f", "64"
+ * @param {Array<number>=}
+ *      An optional array to write converted samples to.  Useful for writing to typed arrays.
  */
-function toBitDepth(samples, originalBitDepth, targetBitDepth) {
+function toBitDepth(samples, originalBitDepth, targetBitDepth, outputArray) {
     validateBitDepths_(originalBitDepth, targetBitDepth);
+    outputArray = outputArray || samples;
     const toFunction = getBitDepthFunction_(originalBitDepth, targetBitDepth);
     const len  = samples.length;
     const codecArgs = {
@@ -106,9 +109,9 @@ function toBitDepth(samples, originalBitDepth, targetBitDepth) {
         "target": targetBitDepth
     };
     for (let i=0; i<len; i++) {
-        samples[i] = sign8Bit_(samples[i], originalBitDepth);
-        samples[i] = toFunction(samples[i], codecArgs);
-        samples[i] = unsign8Bit_(samples[i], targetBitDepth);
+        outputArray[i] = sign8Bit_(samples[i], originalBitDepth);
+        outputArray[i] = toFunction(outputArray[i], codecArgs);
+        outputArray[i] = unsign8Bit_(outputArray[i], targetBitDepth);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -92,8 +92,8 @@ const CODECS = {
  *      One of "8", "16", "24", "32", "32f", "64"
  * @param {string} targetBitDepth The new bit depth of the data.
  *      One of "8", "16", "24", "32", "32f", "64"
- * @param {Array<number>=}
- *      An optional array to write converted samples to.  Useful for writing to typed arrays.
+ * @param {Array<number>=} outputArray An optional array to write converted samples to.
+ *      Useful for writing to typed arrays.
  */
 function toBitDepth(samples, originalBitDepth, targetBitDepth, outputArray) {
     validateBitDepths_(originalBitDepth, targetBitDepth);

--- a/index.js
+++ b/index.js
@@ -95,21 +95,19 @@ const CODECS = {
  */
 function toBitDepth(samples, originalBitDepth, targetBitDepth) {
     validateBitDepths_(originalBitDepth, targetBitDepth);
-    let toFunction = getBitDepthFunction_(originalBitDepth, targetBitDepth);
-    let len = samples.length;
+    const toFunction = getBitDepthFunction_(originalBitDepth, targetBitDepth);
+    const len  = samples.length;
+    const codecArgs = {
+        "oldNegative": MAX_VALUES[originalBitDepth] / 2,
+        "newNegative": MAX_VALUES[targetBitDepth] / 2,
+        "oldPositive": MAX_VALUES[originalBitDepth] / 2 - 1,
+        "newPositive": MAX_VALUES[targetBitDepth] / 2 - 1,
+        "original": originalBitDepth,
+        "target": targetBitDepth
+    };
     for (let i=0; i<len; i++) {        
         samples[i] = sign8Bit_(samples[i], originalBitDepth);
-        samples[i] = toFunction(
-                samples[i],
-                {
-                    "oldNegative": MAX_VALUES[originalBitDepth] / 2,
-                    "newNegative": MAX_VALUES[targetBitDepth] / 2,
-                    "oldPositive": MAX_VALUES[originalBitDepth] / 2 - 1,
-                    "newPositive": MAX_VALUES[targetBitDepth] / 2 - 1,
-                    "original": originalBitDepth,
-                    "target": targetBitDepth
-                }
-            );
+        samples[i] = toFunction(samples[i], codecArgs);
         samples[i] = unsign8Bit_(samples[i], targetBitDepth);
     }
 }

--- a/index.js
+++ b/index.js
@@ -105,7 +105,7 @@ function toBitDepth(samples, originalBitDepth, targetBitDepth) {
         "original": originalBitDepth,
         "target": targetBitDepth
     };
-    for (let i=0; i<len; i++) {        
+    for (let i=0; i<len; i++) {
         samples[i] = sign8Bit_(samples[i], originalBitDepth);
         samples[i] = toFunction(samples[i], codecArgs);
         samples[i] = unsign8Bit_(samples[i], targetBitDepth);

--- a/test/interface.js
+++ b/test/interface.js
@@ -11,8 +11,15 @@ describe("interface", function() {
     let bitdepth = require("../test/loader.js");
     
     it("Should have the toBitDepth function available", function() {
-        data = ["0"];
+        const data = ["0"];
         bitdepth.toBitDepth(data, "8", "8");
         assert.ok(data);
+    });
+
+    it("Should write to a provided output array", function(){
+        const samples = [0, 255];
+        const output  = new Array(samples.length);
+        bitdepth.toBitDepth(samples, "8", "8", output);
+        assert.deepEqual(output, samples);
     });
 });


### PR DESCRIPTION
I needed a way to be able to convert the bit depth of samples without altering the original array of samples and write the output to a typed array.  Converting a typed array to a normal array as an intermediary step to convert bit depths seems awkward to me.

It does add a 4th optional argument to toBitDepth(), but I couldn't come up with a better way.